### PR TITLE
Poll: Simplify Function Calls

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,6 +16,8 @@ jobs:
     # install and cache dependencies
     - name: Install boost
       run: sudo apt-get install libboost-all-dev
+    - name: configure
+      run: mkdir build && cd build && cmake ..
     - name: build
       run: cmake --build build
     - name: test
@@ -31,6 +33,6 @@ jobs:
     - name: configure
       run: mkdir build && cd build && cmake ..
     - name: build
-      run: cmake --build build --config Debug
+      run: cmake --build build
     - name: test
       run: cd build && ctest

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,12 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     # install and cache dependencies
-    - name: Cache boost
-      uses: actions/cache@v1.0.3
-      id: cache-boost
-      with:
-        path: "~/boost"
-        key: libboost-all-dev
     - name: Install boost
       run: sudo apt-get install libboost-all-dev
     - name: build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,43 +21,22 @@ jobs:
         path: "~/boost"
         key: libboost-all-dev
     - name: Install boost
-      env:
-        CACHE_HIT: ${{steps.cache-boost.outputs.cache-hit}}
-      run: |
-        if [[ "$CACHE_HIT" == 'true' ]]; then
-          sudo cp --force --recursive ~/boost/* /
-        else
-          sudo apt-get update && sudo apt-get install -yq libboost-all-dev
-          mkdir -p ~/boost
-          for dep in libboost-all-dev; do
-              dpkg -L $dep | while IFS= read -r f; do if test -f $f; then echo $f; fi; done | xargs cp --parents --target-directory ~/boost/
-          done
-        fi
-    # build project
-    - name: set environment variables
-      run: |
-        
-    - name: configure
-      run: |
-        export BOOST_ROOT= ~/boost
-        export BOOST_INCLUDEDIR= ~/boost
-        export BOOST_LIBRARYDIR= ~/boost/libs
-        mkdir build && cd build && cmake ..
-        
+      run: sudo apt-get install libboost-all-dev
     - name: build
       run: cmake --build build
     - name: test
       run: cd build && ctest
 
-#  build-windows:
+  build-windows:
 
-#   runs-on: windows-latest
-    
-#    steps:
-#    - uses: actions/checkout@v1
-#    - name: configure
-#      run: mkdir build && cd build && cmake ..
-#    - name: build
-#      run: cmake --build build --config Debug
-#    - name: test
-#      run: cd build && ctest
+   runs-on: windows-latest
+   steps:
+    - uses: actions/checkout@v2
+    - name: Install Boost
+      run: choco install boost-msvc-14.2
+    - name: configure
+      run: mkdir build && cd build && cmake ..
+    - name: build
+      run: cmake --build build --config Debug
+    - name: test
+      run: cd build && ctest

--- a/core/net/Socket.h
+++ b/core/net/Socket.h
@@ -30,9 +30,9 @@
 #include <poll.h>
 #endif //WIN64 or Linux checks for the compiler
 #ifdef __unix__
-#define socketPoll poll
+#define SOCKETPOLL poll
 #elif _WIN32
-#define socketPoll WSAPoll
+#define SOCKETPOLL WSAPoll
 #endif
 // Protocols
 #include "Protocols.h"

--- a/core/net/Socket.h
+++ b/core/net/Socket.h
@@ -29,6 +29,11 @@
 #include <fcntl.h>
 #include <poll.h>
 #endif //WIN64 or Linux checks for the compiler
+#ifdef __unix__
+#define socketPoll poll
+#elif _WIN32
+#define socketPoll WSAPoll
+#endif
 // Protocols
 #include "Protocols.h"
 #include "NetConfig.h"

--- a/core/net/tcp/tcpsocket.cpp
+++ b/core/net/tcp/tcpsocket.cpp
@@ -1,6 +1,7 @@
 #include "tcpsocket.h"
 
 
+
 TCPSocket::TCPSocket(int fd) : Socket(fd) {
 	mPollFD.fd = mSocketFD;
 	mPollFD.events = POLLIN;
@@ -79,11 +80,7 @@ bool TCPSocket::connectWithTimeout(std::string address, std::string port, int se
 	mPollFD.events = POLLIN;
 }
 bool TCPSocket::canReceive(int timeout) {
-#ifdef __linux__
-	int status = poll(&mPollFD, 1, timeout);
-#elif _WIN32
-	int status = WSAPoll(&mPollFD, 1, timeout);
-#endif
+	int status = socketPoll(&mPollFD, 1, timeout);
 	if (status == -1) {
 		throw SocketException("Error while pooling connection");
 	}

--- a/core/net/tcp/tcpsocket.cpp
+++ b/core/net/tcp/tcpsocket.cpp
@@ -80,7 +80,7 @@ bool TCPSocket::connectWithTimeout(std::string address, std::string port, int se
 	mPollFD.events = POLLIN;
 }
 bool TCPSocket::canReceive(int timeout) {
-	int status = socketPoll(&mPollFD, 1, timeout);
+	int status = SOCKETPOLL(&mPollFD, 1, timeout);
 	if (status == -1) {
 		throw SocketException("Error while pooling connection");
 	}

--- a/core/net/tcp/tcpsocket.h
+++ b/core/net/tcp/tcpsocket.h
@@ -15,9 +15,6 @@
  */
 #ifndef PLAYERLINK_CORE_TCPSOCKET_H
 #define PLAYERLINK_CORE_TCPSOCKET_H
-#ifdef __linux__
-#include <poll.h>
-#endif
 #include "net/Socket.h"
 #define TIMEOUT_SECONDS 2
 #define TIMEOUT_MICROSECONDS 0

--- a/server/net/TCPServer.cpp
+++ b/server/net/TCPServer.cpp
@@ -75,11 +75,7 @@ void TCPServer::unmonitor(TCPSocket& fd) {
 
 std::vector<TCPSocket> TCPServer::getSocketEvents(int timeout) {
 	std::vector<TCPSocket> events;
-#ifdef __linux__
-	int status = poll(&mMonitorFDs[0], mMonitorFDs.size(), timeout);
-#elif _WIN32
-	int status = WSAPoll(&mMonitorFDs[0], mMonitorFDs.size(), timeout);
-#endif
+	int status = socketPoll(&mMonitorFDs[0], mMonitorFDs.size(), timeout);
 	if (status == -1) {
 		throw SocketException("Error while pooling socket connection");
 	}

--- a/server/net/TCPServer.cpp
+++ b/server/net/TCPServer.cpp
@@ -75,7 +75,7 @@ void TCPServer::unmonitor(TCPSocket& fd) {
 
 std::vector<TCPSocket> TCPServer::getSocketEvents(int timeout) {
 	std::vector<TCPSocket> events;
-	int status = socketPoll(&mMonitorFDs[0], mMonitorFDs.size(), timeout);
+	int status = SOCKETPOLL(&mMonitorFDs[0], mMonitorFDs.size(), timeout);
 	if (status == -1) {
 		throw SocketException("Error while pooling socket connection");
 	}


### PR DESCRIPTION
The poll function is called using `poll` in UNIX devices and with `WSAPoll` in Windows. I have added some macros to create an alias `SOCKETPOLL` to be used in the code instead of clumsy `#ifdef` clauses.